### PR TITLE
Fix cannot import name 'Iterable' error

### DIFF
--- a/pygal/_compat.py
+++ b/pygal/_compat.py
@@ -20,7 +20,7 @@
 from __future__ import division
 
 import sys
-from collections import Iterable
+from collections.abc import Iterable
 from datetime import datetime, timedelta, tzinfo
 
 if sys.version_info[0] == 3:


### PR DESCRIPTION
在 Ubuntu24.04 下使用报错：

```
Traceback (most recent call last):
  File "/usr/bin/pygalgen", line 9, in <module>
    import pygal
  File "/usr/local/lib/python3.12/dist-packages/pygal/__init__.py", line 33, in <module>
    from pygal.graph.bar import Bar
  File "/usr/local/lib/python3.12/dist-packages/pygal/graph/bar.py", line 26, in <module>
    from pygal.graph.graph import Graph
  File "/usr/local/lib/python3.12/dist-packages/pygal/graph/graph.py", line 26, in <module>
    from pygal._compat import is_list_like, is_str, to_str
  File "/usr/local/lib/python3.12/dist-packages/pygal/_compat.py", line 23, in <module>
    from collections import Iterable
ImportError: cannot import name 'Iterable' from 'collections' (/usr/lib/python3.12/collections/__init__.py)
```

原因：

<img width="813" alt="image" src="https://github.com/user-attachments/assets/77910187-333f-4fe9-beff-017975b608d9" />
